### PR TITLE
Redesign of packetization and logging logic to include in-memory buffers

### DIFF
--- a/bus_rpi/bus.py
+++ b/bus_rpi/bus.py
@@ -80,16 +80,12 @@ def read_response(ser: serial.Serial, last_argument_sent=None):
         packet = header_and_size + rest
 
         try:
-            message_type, payload = parse_response_packet(packet)
-            print(f"[RECEIVED] Type: {message_type}, Payload Length: {len(payload)} bytes")
+            group_id, payload = struct.unpack('<B', packet[12:13])[0], packet[13:-4]
+            index = struct.unpack('<I', payload[:4])[0]  # get index from payload
+            print(f"[RECEIVED] Group: {group_id}, Index: {index}, Payload Length: {len(payload)} bytes")
 
-            if last_argument_sent and '_' in last_argument_sent:
-                filename = f"{last_argument_sent}.bin"
-            else:
-                # fallback to a timestamp if arg not usable
-                filename = f"{message_type}_{int(time.time())}.bin"
-
-            folder = f"received_logs/type{message_type}"
+            filename = f"{group_id}_{index}.bin"
+            folder = f"received_logs/group{group_id}"
             os.makedirs(folder, exist_ok=True)
             with open(os.path.join(folder, filename), 'wb') as f:
                 f.write(packet)

--- a/fsw/config.json
+++ b/fsw/config.json
@@ -1,7 +1,7 @@
 {
-  "chunk_entries": {
-    "type1": 10,
-    "type2": 10,
-    "type3": 7
+  "buffer_entries": {
+    "group1": 9,
+    "group2": 7,
+    "group3": 2
   }
 }

--- a/fsw/config.json
+++ b/fsw/config.json
@@ -1,7 +1,7 @@
 {
   "buffer_entries": {
-    "group1": 9,
-    "group2": 7,
+    "group1": 8,
+    "group2": 6,
     "group3": 2
   }
 }

--- a/fsw/dt_fsw.py
+++ b/fsw/dt_fsw.py
@@ -49,6 +49,24 @@ with open(file_name, 'w', encoding='UTF8', newline='') as f:
     writer = csv.writer(f)
     writer.writerow(header)
 
+STATE_CODES = {
+    'CHG': 0,
+    'DIS': 1,
+    'REST': 2,
+    'CHG_REST': 3,
+    'DIS_REST': 4,
+    'CHG_LOW': 5,
+    'DIS_LOW': 6,
+    'UNKNOWN': 255
+}
+
+MODE_CODES = {
+    'CYCLE': 0,
+    'TEST': 1,
+    'UNKNOWN': 255
+}
+
+
 def init_GPIO():
     GPIO.setmode(GPIO.BCM)
     GPIO.setup(ADDRS.EN_CHG_GPIO_LIST[0], GPIO.OUT)
@@ -482,8 +500,8 @@ if __name__ == "__main__":
                     0,  # replace with actual reset count
                     time_switches[0], time_switches[1], time_switches[2],
                     ch0.test_sequence, ch1.test_sequence, ch2.test_sequence,
-                    ch0.state, ch1.state, ch2.state,
-                    ch0.mode, ch1.mode, ch2.mode,
+                    STATE_CODES.get(ch0.state, 255), STATE_CODES.get(ch1.state, 255), STATE_CODES.get(ch2.state, 255),  
+                    MODE_CODES.get(ch0.mode, 255), MODE_CODES.get(ch1.mode, 255), MODE_CODES.get(ch2.mode, 255),  
                     get_CPU_temperature(),
                     get_CPU_voltage()
                 )

--- a/fsw/dt_fsw.py
+++ b/fsw/dt_fsw.py
@@ -17,8 +17,7 @@ from battery_channel_class import battery_channel
 from FSW_PARAMS_class import FSW_PARAMS
 from FSW_ADDRS_class import FSW_ADDRS
 from packet_handler import (
-    handle_request_packet,
-    build_combined_packet, buffer_and_log_reading,
+    handle_request_packet, buffer_and_log_reading,
 )
 
 # Init serial port to communicate with the mock bus

--- a/fsw/dt_fsw.py
+++ b/fsw/dt_fsw.py
@@ -17,9 +17,8 @@ from battery_channel_class import battery_channel
 from FSW_PARAMS_class import FSW_PARAMS
 from FSW_ADDRS_class import FSW_ADDRS
 from packet_handler import (
-    log_binary_packet,
     handle_request_packet,
-    build_packet_type_1, build_packet_type_2, build_packet_type_3
+    build_combined_packet, buffer_and_log_reading,
 )
 
 # Init serial port to communicate with the mock bus
@@ -435,13 +434,13 @@ if __name__ == "__main__":
                 #TODO write to memory to prepare for reset
                 log_sensor_data(time_iter_s, sensor_data, ch0, ch1, ch2)
                 
-                payload_1 = build_packet_type_1(
-                time_s=time_iter_s,
-                voltages=[ch0.volt_v, ch1.volt_v, ch2.volt_v],
-                currents=[ch0.curr_ma, ch1.curr_ma, ch2.curr_ma],
-                temps=[ch0.temp_c, ch1.temp_c, ch2.temp_c]
+                reading_1 = (
+                    time_iter_s,
+                    ch0.volt_v, ch1.volt_v, ch2.volt_v,
+                    ch0.curr_ma, ch1.curr_ma, ch2.curr_ma,
+                    ch0.temp_c, ch1.temp_c, ch2.temp_c
                 )
-                log_binary_packet(1, payload_1)
+                buffer_and_log_reading(1, reading_1)
                 
                 print('Tempera: %5.2f, %5.2f, %5.2f' % (temp_iter_c[0], temp_iter_c[1], temp_iter_c[2]))
                 print('Voltage: %5.2f, %5.2f, %5.2f' % (volt_iter_v[0], volt_iter_v[1], volt_iter_v[2]))
@@ -466,19 +465,31 @@ if __name__ == "__main__":
                 if ch2.mode == 'CYCLE':
                     ch2.state_estimate(volt_iter_v[2], curr_iter_ma[2], time_iter_s)
                 
-                payload_3 = build_packet_type_3(ch0, ch1, ch2)
-                log_binary_packet(3, payload_3)
+                reading_3 = (
+                    time_iter_s,
+                    ch0.est_soc, ch0.est_volt_v, ch0.est_cov_state[0, 0], ch0.est_cov_state[1, 1], ch0.est_capacity_as, ch0.est_cov_param,
+                    ch1.est_soc, ch1.est_volt_v, ch1.est_cov_state[0, 0], ch1.est_cov_state[1, 1], ch1.est_capacity_as, ch1.est_cov_param,
+                    ch2.est_soc, ch2.est_volt_v, ch2.est_cov_state[0, 0], ch2.est_cov_state[1, 1], ch2.est_capacity_as, ch2.est_cov_param,
+                )
+                buffer_and_log_reading(3, reading_3)
+
                 #print('heartbeat, fast loop')
                 time_prev_fast_s = time_iter_s
-                           
+                
             if time_iter_s > time_prev_log2_s + PARAMS.DT_LOG2_S:
-                payload_2 = build_packet_type_2(
-                    channels=[ch0, ch1, ch2],
-                    resets=0,
-                    time_switches=time_switches,
-                    cpu_temp=get_CPU_temperature(),
-                    cpu_volt=get_CPU_voltage())
-                log_binary_packet(2, payload_2)
+                reading_2 = (
+                    time_iter_s,
+                    ch0.cycle_count, ch1.cycle_count, ch2.cycle_count,
+                    0,  # replace with actual reset count
+                    time_switches[0], time_switches[1], time_switches[2],
+                    ch0.test_sequence, ch1.test_sequence, ch2.test_sequence,
+                    ch0.state, ch1.state, ch2.state,
+                    ch0.mode, ch1.mode, ch2.mode,
+                    get_CPU_temperature(),
+                    get_CPU_voltage()
+                )
+                buffer_and_log_reading(2, reading_2)
+
 
             if time_iter_s > time_prev_heat_s + PARAMS.DT_HEAT_S:
                 #check if heater should be on

--- a/fsw/dt_fsw.py
+++ b/fsw/dt_fsw.py
@@ -438,12 +438,12 @@ if __name__ == "__main__":
                 #chg_val_prev = ch2.chg_val
                 
                 #push those actuator values to the board
-#                if ch0.update_act:
-#                    update_actuators(ch0)
-#                if ch1.update_act:
-#                    update_actuators(ch1)
-#                if ch2.update_act:
-#                    update_actuators(ch2)
+                if ch0.update_act:
+                    update_actuators(ch0)
+                if ch1.update_act:
+                    update_actuators(ch1)
+                if ch2.update_act:
+                    update_actuators(ch2)
             
             pulse = ch0.pulse_state or ch1.pulse_state or ch2.pulse_state
             if (time_iter_s > time_prev_log_s + PARAMS.DT_LOG_S) or (pulse and time_iter_s > time_prev_log_s + PARAMS.DT_SENSORS_S):
@@ -505,8 +505,9 @@ if __name__ == "__main__":
                     get_CPU_temperature(),
                     get_CPU_voltage()
                 )
+                print(f"Logging group 2 at {reading_2[0]:.2f}s")
                 buffer_and_log_reading(2, reading_2)
-
+                time_prev_log2_s = time_iter_s
 
             if time_iter_s > time_prev_heat_s + PARAMS.DT_HEAT_S:
                 #check if heater should be on

--- a/fsw/packet_handler.py
+++ b/fsw/packet_handler.py
@@ -3,6 +3,7 @@ import zlib
 import os
 import time
 import json
+import numpy as np
 
 HEADER = b'\x30\x20\x30\x20\x30\x20\x30\x20'
 
@@ -14,16 +15,19 @@ CONFIG_FILE = os.path.join(BASE_DIR, 'config.json')
 
 with open(CONFIG_FILE, 'r') as f:
     CONFIG = json.load(f)
-CHUNK_ENTRIES = CONFIG.get("chunk_entries", {})
-print("[DEBUG] Loaded chunk entries:", CHUNK_ENTRIES)
+BUFFER_ENTRIES = CONFIG.get("buffer_entries", {})
+
+reading_buffers = {
+    1: [],
+    2: [],
+    3: []
+}
 
 # CRC and Packet Builder
 def compute_crc32(data: bytes) -> int:
     return zlib.crc32(data)
 
-"""
-Build response packet in the format - [HEADER][SIZE][TYPE][PAYLOAD][CRC32]
-"""
+# Build response packet in the format - [HEADER][SIZE][TYPE][PAYLOAD][CRC32]
 def build_response_packet(msg_type: int, payload: bytes) -> bytes:
     size = len(payload) + 1 + 4
     size_bytes = struct.pack('<I', size)
@@ -33,114 +37,84 @@ def build_response_packet(msg_type: int, payload: bytes) -> bytes:
 
     return HEADER + packet_wo_crc + struct.pack('<I', crc)
 
-def get_chunk_folder(msg_type: int) -> str:
-    folder = os.path.join(LOG_BASE_DIR, f"type{msg_type}")
+def get_group_folder(group_id: int) -> str:
+    folder = os.path.join(LOG_BASE_DIR, f"group{group_id}")
     os.makedirs(folder, exist_ok=True)
     return folder
 
-def get_pointer_path(msg_type: int, pointer_name='current') -> str:
-    return os.path.join(get_chunk_folder(msg_type), f'.{pointer_name}_pointer')
+# generates the next filename to write
+def get_next_group_file(group_id: int) -> str:
+    folder = get_group_folder(group_id)
+    index = get_latest_index(group_id) + 1
+    return os.path.join(folder, f"{group_id}_{index}.bin")
 
-def read_pointer(msg_type: int, pointer_name='current') -> int:
-    path = get_pointer_path(msg_type, pointer_name)
-    try:
-        with open(path, 'r') as f:
-            return int(f.read().strip())
-    except (FileNotFoundError, ValueError):
-        return 0
-    
-def write_pointer(msg_type: int, value: int, pointer_name='current'):
-    path = get_pointer_path(msg_type, pointer_name)
-    with open(path, 'w') as f:
-        f.write(str(value % MAX_FILE_INDEX))
-
-def get_current_chunk_file(msg_type: int) -> str:
-    folder = get_chunk_folder(msg_type)
-    index = read_pointer(msg_type, 'current')
-    return os.path.join(folder, f"{msg_type}_{index}.bin")
-
-def increment_pointer(msg_type: int):
-    index = read_pointer(msg_type, 'current') + 1
-    write_pointer(msg_type, index, 'current')
-
-def log_binary_packet(msg_type: int, payload: bytes):
-    chunk_file = get_current_chunk_file(msg_type)
-    entry = build_response_packet(msg_type, payload)
-
-#    with open(chunk_file, 'ab') as f:
-  with open(chunk_file, 'wb') as f:
+def log_binary_packet(group_id: int, payload: bytes):
+    group_file = get_next_group_file(group_id)
+    entry = build_response_packet(group_id, payload)
+    with open(group_file, 'wb') as f:
         f.write(entry)
+    print(f"[LOG] Group {group_id}: Written to {group_file}")
 
-    chunk_limit = CHUNK_ENTRIES.get(f"type{msg_type}", 5)
-    print(f"[DEBUG] Using chunk limit for type{msg_type}: {chunk_limit}")
-    with open(chunk_file, 'rb') as f:
-        count = 0
-        while f.read(8):
-            size_bytes = f.read(4)
-            if len(size_bytes) < 4:
-                break
-            size = struct.unpack('<I', size_bytes)[0]
-            f.read(size)
-            count += 1
+# Build packets for message groups
+def build_packet_group_1(reading_list):
+    payload = b''
+    for reading in reading_list:
+        # (time_s, volt0, volt1, volt2, curr0, curr1, curr2, temp0, temp1, temp2) = reading
+        # arr = np.array([time_s, volt0, volt1, volt2, curr0, curr1, curr2, temp0, temp1, temp2], dtype=np.float16)
+        arr = np.array(reading, dtype=np.float16)
+        payload += arr.tobytes()
+    return payload
 
-    if count >= chunk_limit:
-        increment_pointer(msg_type)
+def build_packet_group_2(reading_list):
+    payload = b''
+    for reading in reading_list:
+        (
+            time_s, 
+            cyc0, cyc1, cyc2, 
+            resets, 
+            tms0, tms1, tms2, 
+            seq0, seq1, seq2, 
+            state0, state1, state2, 
+            mode0, mode1, mode2, 
+            cpu_temp, cpu_volt
+        ) = reading
 
-# Build packets for message types
+        int_part = struct.pack('<3B H 3H 3B 3B 3B', cyc0, cyc1, cyc2, resets, tms0, tms1, tms2, seq0, seq1, seq2, state0, state1, state2, mode0, mode1, mode2)
+        float_part = np.array([time_s, cpu_temp, cpu_volt], dtype=np.float16).tobytes()
+        payload += float_part + int_part
+    return payload
 
-def build_packet_type_1(time_s: float, voltages, currents, temps) -> bytes:
-    return struct.pack('<f3f3f3f', time_s, *voltages, *currents, *temps)
+def build_packet_group_3(reading_list):
+    payload = b''
+    for reading in reading_list:
+        (
+            time_s, 
+            soc0, volt0, cov00_0, cov11_0, cap0, param0, 
+            soc1, volt1, cov00_1, cov11_1, cap1, param1, 
+            soc2, volt2, cov00_2, cov11_2, cap2, param2
+        ) = reading
 
-def build_packet_type_2(channels, resets, time_switches, cpu_temp: float, cpu_volt: float) -> bytes:
-    return struct.pack(
-        '<3B H 3H 3B 3B 3B 2f',
-        *[ch.cycle_count for ch in channels],
-        resets,
-        *time_switches,
-        *[ch.test_sequence for ch in channels],
-        *[ch.state_code for ch in channels],
-        *[ch.mode_code for ch in channels],
-        cpu_temp,
-        cpu_volt
-    )
+        timestamp_bytes = np.array([time_s], dtype=np.float16).tobytes()
+        estimator_data = struct.pack('<18f', soc0, volt0, cov00_0, cov11_0, cap0, param0, soc1, volt1, cov00_1, cov11_1, cap1, param1, soc2, volt2, cov00_2, cov11_2, cap2, param2)
+        payload += timestamp_bytes + estimator_data
+    return payload
 
-def build_packet_type_3(ch0, ch1, ch2) -> bytes:
-#     print(ch0.est_cov_state)
-#     print(ch0.est_cov_state[0, 0])
-#     print(ch0.est_cov_state[1, 1])
-    return struct.pack(
-        #'<' + '2f4f4f4f4f' * 3,
-        '<' + '1f1f1f1f1f1f' * 3,
-        float(ch0.est_soc),
-        float(ch0.est_volt_v),
-        float(ch0.est_cov_state[0,0]),
-        float(ch0.est_cov_state[1,1]),
-        float(ch0.est_capacity_as),
-        float(ch0.est_cov_param),
-        #ch0.ohmic_resistance,
-        #ch0.capacitance,
-        #ch0.resistance,
+def buffer_and_log_reading(group_id: int, reading: tuple):
+    reading_buffers[group_id].append(reading)
+    buffer_limit = BUFFER_ENTRIES.get(f"group{group_id}", 5)
+
+    if len(reading_buffers[group_id]) >= buffer_limit:
+        if group_id == 1:
+            payload = build_packet_group_1(reading_buffers[group_id])
+        elif group_id == 2:
+            payload = build_packet_group_2(reading_buffers[group_id])
+        elif group_id == 3:
+            payload = build_packet_group_3(reading_buffers[group_id])
+        else:
+            raise ValueError("Invalid group ID")
         
-        float(ch1.est_soc),
-        float(ch1.est_volt_v),
-        float(ch1.est_cov_state[0,0]),
-        float(ch1.est_cov_state[1,1]),
-        float(ch1.est_capacity_as),
-        float(ch1.est_cov_param),
-        #ch1.ohmic_resistance,
-        #ch1.capacitance,
-        #ch1.resistance,
-
-        float(ch2.est_soc),
-        float(ch2.est_volt_v),
-        float(ch2.est_cov_state[0,0]),
-        float(ch2.est_cov_state[1,1]),
-        float(ch2.est_capacity_as),
-        float(ch2.est_cov_param)
-        #ch2.ohmic_resistance,
-        #ch2.capacitance,
-        #ch2.resistance
-        )
+        log_binary_packet(group_id, payload)
+        reading_buffers[group_id].clear()
 
 def parse_request_packet(packet: bytes):
     if len(packet) < 17 or packet[:8] != HEADER:
@@ -153,7 +127,7 @@ def parse_request_packet(packet: bytes):
         raise ValueError("Checksum mismatch")
     return msg_type, payload
 
-GLOBAL_POINTER_PATH = os.path.join(LOG_BASE_DIR, '.last_sent_msg_type')
+GLOBAL_POINTER_PATH = os.path.join(LOG_BASE_DIR, '.last_sent_group')
 
 def read_global_pointer() -> int:
     try:
@@ -162,21 +136,22 @@ def read_global_pointer() -> int:
     except (FileNotFoundError, ValueError):
         return 0
 
-def write_global_pointer(msg_type: int):
+def write_global_pointer(group_id: int):
     with open(GLOBAL_POINTER_PATH, 'w') as f:
-        f.write(str(msg_type % 256))
+        f.write(str(group_id % 256))
 
-def get_file_path(msg_type: int, index: int) -> str:
-    folder = get_chunk_folder(msg_type)
-    filename = f"{msg_type}_{index}.bin"
+# for specific requests
+def get_file_path(group_id: int, index: int) -> str:
+    folder = get_group_folder(group_id)
+    filename = f"{group_id}_{index}.bin"
     path = os.path.join(folder, filename)
     return path if os.path.exists(path) else None
 
-def get_latest_index(msg_type: int) -> int:
-    folder = get_chunk_folder(msg_type)
+def get_latest_index(group_id: int) -> int:
+    folder = get_group_folder(group_id)
     max_index = -1
     for f in os.listdir(folder):
-        if f.endswith(".bin") and f.startswith(f"{msg_type}_"):
+        if f.endswith(".bin") and f.startswith(f"{group_id}_"):
             try:
                 idx = int(f.split('_')[1].replace(".bin", ""))
                 if idx > max_index:
@@ -185,50 +160,66 @@ def get_latest_index(msg_type: int) -> int:
                 continue
     return max_index
 
+def get_pointer_path(group_id: int) -> str:
+    return os.path.join(get_group_folder(group_id), f".last_sent_pointer")
+
+def read_pointer(group_id: int) -> int:
+    path = get_pointer_path(group_id)
+    try:
+        with open(path, 'r') as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+def write_pointer(group_id: int, value: int):
+    path = get_pointer_path(group_id)
+    with open(path, 'w') as f:
+        f.write(str(value % MAX_FILE_INDEX))
+
 def get_next_packet_to_send() -> bytes:
-    for msg_type in [3, 2, 1]:  # Priority order
-        last_sent = read_pointer(msg_type, 'last_sent')
-        latest = get_latest_index(msg_type)
+    for group_id in [3, 2, 1]:  # Priority order
+        last_sent = read_pointer(group_id)
+        latest = get_latest_index(group_id)
 
         if latest > last_sent:
-            path = get_file_path(msg_type, last_sent + 1)
+            path = get_file_path(group_id, last_sent + 1)
             if path:
                 with open(path, 'rb') as f:
                     data = f.read()
 
-                write_pointer(msg_type, last_sent + 1, 'last_sent')
-                write_global_pointer(msg_type)
-                print(f"[DEBUG] last_sent = {last_sent}, latest = {latest} for msg_type {msg_type}")
+                write_pointer(group_id, last_sent + 1)
+                write_global_pointer(group_id)
+                print(f"[DEBUG] last_sent = {last_sent}, latest = {latest} for group {group_id}")
                 return data
     return None  # No packets ready
 
 def get_last_sent_packet() -> bytes:
-    msg_type = read_global_pointer()
-    last_sent_index = read_pointer(msg_type, 'last_sent')
+    group_id = read_global_pointer()
+    last_sent_index = read_pointer(group_id)
 
-    path = get_file_path(msg_type, last_sent_index)
+    path = get_file_path(group_id, last_sent_index)
     if path and os.path.exists(path):
         with open(path, 'rb') as f:
             return f.read()
     return None
 
 def handle_request_packet(packet: bytes) -> bytes:
-    msg_type, payload = parse_request_packet(packet)
+    req_type, payload = parse_request_packet(packet)
 
-    if msg_type == 0:
+    if req_type == 0:
         print("Resend request received.")
         return get_last_sent_packet()
 
-    elif msg_type == 2:
+    elif req_type == 2:
         print(f"Specific packet request received with argument: {payload}")
-        requested_type, requested_index = parse_specific_request_argument(payload)
-        if requested_type is not None and requested_index is not None:
-            path = get_file_path(requested_type, requested_index)
+        requested_group, requested_index = parse_specific_request_argument(payload)
+        if requested_group is not None and requested_index is not None:
+            path = get_file_path(requested_group, requested_index)
             if path:
                 with open(path, 'rb') as f:
                     return f.read()
             else:
-                print(f"[ERROR] File not found: {requested_type}_{requested_index}.bin")
+                print(f"[ERROR] File not found: {requested_group}_{requested_index}.bin")
                 return None
         else:
             print("[ERROR] Failed to decode specific request payload.")
@@ -241,8 +232,8 @@ def handle_request_packet(packet: bytes) -> bytes:
 def parse_specific_request_argument(payload: bytes):
     try:
         decoded = payload.decode('utf-8')
-        msg_type_str, index_str = decoded.split('_')
-        return int(msg_type_str), int(index_str)
+        group_str, index_str = decoded.split('_')
+        return int(group_str), int(index_str)
     except Exception:
         print("[ERROR] Invalid specific packet argument. Expected something like '2_3'")
         return None, None

--- a/fsw/packet_handler.py
+++ b/fsw/packet_handler.py
@@ -15,6 +15,7 @@ CONFIG_FILE = os.path.join(BASE_DIR, 'config.json')
 with open(CONFIG_FILE, 'r') as f:
     CONFIG = json.load(f)
 CHUNK_ENTRIES = CONFIG.get("chunk_entries", {})
+print("[DEBUG] Loaded chunk entries:", CHUNK_ENTRIES)
 
 # CRC and Packet Builder
 def compute_crc32(data: bytes) -> int:
@@ -66,10 +67,12 @@ def log_binary_packet(msg_type: int, payload: bytes):
     chunk_file = get_current_chunk_file(msg_type)
     entry = build_response_packet(msg_type, payload)
 
-    with open(chunk_file, 'ab') as f:
+#    with open(chunk_file, 'ab') as f:
+  with open(chunk_file, 'wb') as f:
         f.write(entry)
 
-    chunk_limit = CHUNK_ENTRIES.get(f"type{msg_type}", 20)
+    chunk_limit = CHUNK_ENTRIES.get(f"type{msg_type}", 5)
+    print(f"[DEBUG] Using chunk limit for type{msg_type}: {chunk_limit}")
     with open(chunk_file, 'rb') as f:
         count = 0
         while f.read(8):
@@ -195,6 +198,7 @@ def get_next_packet_to_send() -> bytes:
 
                 write_pointer(msg_type, last_sent + 1, 'last_sent')
                 write_global_pointer(msg_type)
+                print(f"[DEBUG] last_sent = {last_sent}, latest = {latest} for msg_type {msg_type}")
                 return data
     return None  # No packets ready
 

--- a/fsw/packet_handler.py
+++ b/fsw/packet_handler.py
@@ -12,6 +12,8 @@ MAX_FILE_INDEX = 10**6
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOG_BASE_DIR = os.path.join(BASE_DIR, 'log')
 CONFIG_FILE = os.path.join(BASE_DIR, 'config.json')
+BUFFER_BACKUP_FILE = os.path.join(LOG_BASE_DIR, 'buffers_backup.json')
+
 
 with open(CONFIG_FILE, 'r') as f:
     CONFIG = json.load(f)
@@ -22,6 +24,30 @@ reading_buffers = {
     2: [],
     3: []
 }
+
+# Load persisted buffer if it exists
+def load_buffer_backup():
+    if os.path.exists(BUFFER_BACKUP_FILE):
+        try:
+            with open(BUFFER_BACKUP_FILE, 'r') as f:
+                data = json.load(f)
+                for key in reading_buffers:
+                    reading_buffers[key] = data.get(str(key), [])
+            print("[INFO] Buffer state restored from backup.")
+        except Exception as e:
+            print(f"[ERROR] Failed to load buffer backup: {e}")
+
+# Save current buffer to backup file
+# to be Called periodically or before power cycle
+def save_buffer_backup():
+    try:
+        with open(BUFFER_BACKUP_FILE, 'w') as f:
+            json.dump(reading_buffers, f)
+        print("[INFO] Buffer state saved.")
+    except Exception as e:
+        print(f"[ERROR] Failed to save buffer backup: {e}")
+
+load_buffer_backup()
 
 # CRC and Packet Builder
 def compute_crc32(data: bytes) -> int:

--- a/ground_utils/packet_parser.py
+++ b/ground_utils/packet_parser.py
@@ -110,5 +110,7 @@ def parse_folder(folder_path):
             parse_bin_file(os.path.join(folder_path, fname))
 
 if __name__ == '__main__':
-    folder = "log_files"  
-    parse_folder(folder)
+#    folder = "log_files"  
+#    parse_folder(folder)
+    file_path = input("Enter file_path:").strip()
+    parse_bin_file(file_path)

--- a/ground_utils/packet_parser.py
+++ b/ground_utils/packet_parser.py
@@ -109,8 +109,7 @@ def parse_packet(packet: bytes):
     size = struct.unpack('<I', packet[8:12])[0]
     group_id = struct.unpack('<B', packet[12:13])[0]
     index = struct.unpack('<I', packet[13:17])[0]  # new index field
-    full_payload = packet[17:17+size-5]  
-    payload = full_payload[4:]
+    payload = packet[17:17+size-8]  
     return group_id, index, payload
 
 def parse_bin_file(file_path):

--- a/ground_utils/packet_parser.py
+++ b/ground_utils/packet_parser.py
@@ -1,5 +1,6 @@
 import struct
 import os
+import json
 
 HEADER = b'\x30\x20\x30\x20\x30\x20\x30\x20'
 
@@ -20,57 +21,87 @@ MODE_NAMES = {
     255: 'UNKNOWN'
 }
 
+# Load buffer configuration to determine entry count
+CONFIG_FILE = "config.json"
+with open(CONFIG_FILE, 'r') as f:
+    config = json.load(f)
+BUFFER_ENTRIES = {
+    1: config.get("buffer_entries", {}).get("group1", 1),
+    2: config.get("buffer_entries", {}).get("group2", 1),
+    3: config.get("buffer_entries", {}).get("group3", 1)
+}
+
 def parse_group_1_packet(payload: bytes):
-    if len(payload) != 20:  # 10 float16 values = 20 bytes
-        raise ValueError("Payload size for group 1 must be 20 bytes")
-    values = struct.unpack('<10e', payload)
-    return {
-        "time": values[0],
-        "voltages": values[1:4],
-        "currents": values[4:7],
-        "temps": values[7:10]
-    }
+    entry_size = 20  # 10 float16 values = 20 bytes
+    total_entries = len(payload) // entry_size
+    parsed_entries = []
+
+    for i in range(total_entries):
+        entry = payload[i*entry_size:(i+1)*entry_size]
+        values = struct.unpack('<10e', entry)
+        parsed_entries.append({
+            "time": values[0],
+            "voltages": values[1:4],
+            "currents": values[4:7],
+            "temps": values[7:10]
+        })
+
+    return parsed_entries
 
 def parse_group_2_packet(payload: bytes):
-    time_s = struct.unpack('<e', payload[:2])[0]
-    unpacked = struct.unpack('<3B H 3H 3B 3B 3B', payload[2:-4])
-    cycle_counts = unpacked[0:3]
-    resets = unpacked[3]
-    time_switches = unpacked[4:7]
-    test_sequences = unpacked[7:10]
-    state_codes = unpacked[10:13]
-    mode_codes = unpacked[13:16]
-    cpu_temp, cpu_volt = struct.unpack('<2e', payload[-4:])
+    entry_size = 2 + struct.calcsize('<3B H 3H 3B 3B 3B') + 4  # time + packed + 2 float16
+    total_entries = len(payload) // entry_size
+    parsed_entries = []
 
-    return {
-        "time": time_s,
-        "cycle_counts": cycle_counts,
-        "resets": resets,
-        "time_switches": time_switches,
-        "test_sequences": test_sequences,
-        "states": [STATE_NAMES.get(code, 'UNKNOWN') for code in state_codes],
-        "modes": [MODE_NAMES.get(code, 'UNKNOWN') for code in mode_codes],
-        "cpu_temp": cpu_temp,
-        "cpu_volt": cpu_volt
-    }
+    for i in range(total_entries):
+        entry = payload[i*entry_size:(i+1)*entry_size]
+        time_s = struct.unpack('<e', entry[:2])[0]
+        unpacked = struct.unpack('<3B H 3H 3B 3B 3B', entry[2:-4])
+        cycle_counts = unpacked[0:3]
+        resets = unpacked[3]
+        time_switches = unpacked[4:7]
+        test_sequences = unpacked[7:10]
+        state_codes = unpacked[10:13]
+        mode_codes = unpacked[13:16]
+        cpu_temp, cpu_volt = struct.unpack('<2e', entry[-4:])
+
+        parsed_entries.append({
+            "time": time_s,
+            "cycle_counts": cycle_counts,
+            "resets": resets,
+            "time_switches": time_switches,
+            "test_sequences": test_sequences,
+            "states": [STATE_NAMES.get(code, 'UNKNOWN') for code in state_codes],
+            "modes": [MODE_NAMES.get(code, 'UNKNOWN') for code in mode_codes],
+            "cpu_temp": cpu_temp,
+            "cpu_volt": cpu_volt
+        })
+
+    return parsed_entries
 
 def parse_group_3_packet(payload: bytes):
-    if len(payload) != 74:  # 1 float16 (2 bytes) + 18 floats (72 bytes)
-        raise ValueError("Payload size for group 3 must be 74 bytes")
-    time_s = struct.unpack('<e', payload[:2])[0]
-    estimator_data = struct.unpack('<18f', payload[2:])
-    channels = []
-    for i in range(3):
-        offset = i * 6
-        channels.append({
-            "estimated_soc": estimator_data[offset + 0],
-            "estimated_voltage": estimator_data[offset + 1],
-            "cov_state_00": estimator_data[offset + 2],
-            "cov_state_11": estimator_data[offset + 3],
-            "capacity": estimator_data[offset + 4],
-            "cov_param": estimator_data[offset + 5]
-        })
-    return {"time": time_s, "channels": channels}
+    entry_size = 2 + struct.calcsize('<18f')  # timestamp + 18 float32s
+    total_entries = len(payload) // entry_size
+    parsed_entries = []
+
+    for i in range(total_entries):
+        entry = payload[i*entry_size:(i+1)*entry_size]
+        time_s = struct.unpack('<e', entry[:2])[0]
+        estimator_data = struct.unpack('<18f', entry[2:])
+        channels = []
+        for j in range(3):
+            offset = j * 6
+            channels.append({
+                "estimated_soc": estimator_data[offset + 0],
+                "estimated_voltage": estimator_data[offset + 1],
+                "cov_state_00": estimator_data[offset + 2],
+                "cov_state_11": estimator_data[offset + 3],
+                "capacity": estimator_data[offset + 4],
+                "cov_param": estimator_data[offset + 5]
+            })
+        parsed_entries.append({"time": time_s, "channels": channels})
+
+    return parsed_entries
 
 def parse_packet(packet: bytes):
     if packet[:8] != HEADER:
@@ -78,8 +109,8 @@ def parse_packet(packet: bytes):
     size = struct.unpack('<I', packet[8:12])[0]
     group_id = struct.unpack('<B', packet[12:13])[0]
     index = struct.unpack('<I', packet[13:17])[0]  # new index field
-    payload = packet[17:17+size-8]  # skip 1 byte group_id + 4 byte index + 4 byte CRC using size
-    crc_recv = struct.unpack('<I', packet[17+size-8:17+size-4])[0]
+    full_payload = packet[17:17+size-5]  
+    payload = full_payload[4:]
     return group_id, index, payload
 
 def parse_bin_file(file_path):

--- a/ground_utils/packet_parser.py
+++ b/ground_utils/packet_parser.py
@@ -20,7 +20,7 @@ MODE_NAMES = {
     255: 'UNKNOWN'
 }
 
-def parse_packet_type_1(payload: bytes):
+def parse_group_1_packet(payload: bytes):
     time_s, *values = struct.unpack('<f3f3f3f', payload)
     voltages = values[0:3]
     currents = values[3:6]
@@ -32,17 +32,19 @@ def parse_packet_type_1(payload: bytes):
         "temps": temps
     }
 
-def parse_packet_type_2(payload: bytes):
-    unpacked = struct.unpack('<3B H 3H 3B 3B 3B 2f', payload)
+def parse_group_2_packet(payload: bytes):
+    time_s = struct.unpack('<e', payload[:2])[0]
+    unpacked = struct.unpack('<3B H 3H 3B 3B 3B', payload[2:-4])
     cycle_counts = unpacked[0:3]
     resets = unpacked[3]
     time_switches = unpacked[4:7]
     test_sequences = unpacked[7:10]
     state_codes = unpacked[10:13]
     mode_codes = unpacked[13:16]
-    cpu_temp, cpu_volt = unpacked[16:18]
+    cpu_temp, cpu_volt = struct.unpack('<2e', payload[-4:])
 
     return {
+        "time": time_s,
         "cycle_counts": cycle_counts,
         "resets": resets,
         "time_switches": time_switches,
@@ -53,32 +55,30 @@ def parse_packet_type_2(payload: bytes):
         "cpu_volt": cpu_volt
     }
 
-def parse_packet_type_3(payload: bytes):
-    fields_per_channel = struct.unpack('<2f4f4f4f4f'*3, payload)
+def parse_group_3_packet(payload: bytes):
+    time_s = struct.unpack('<e', payload[:2])[0]
+    estimator_data = struct.unpack('<18f', payload[2:])
     channels = []
     for i in range(3):
-        offset = i * 18  # 2 + 4 + 4 + 4 + 4 + 4 = 18 floats per channel
-        channel_data = fields_per_channel[offset:offset+18]
+        offset = i * 6
         channels.append({
-            "estimated_soc": channel_data[0],
-            "estimated_voltage": channel_data[1],
-            "cov_state": channel_data[2:6],
-            "capacity": channel_data[6],
-            "ohmic_resistance": channel_data[7],
-            "capacitance": channel_data[8],
-            "resistance": channel_data[9],
-            "cov_param": channel_data[10:]
+            "estimated_soc": estimator_data[offset + 0],
+            "estimated_voltage": estimator_data[offset + 1],
+            "cov_state_00": estimator_data[offset + 2],
+            "cov_state_11": estimator_data[offset + 3],
+            "capacity": estimator_data[offset + 4],
+            "cov_param": estimator_data[offset + 5]
         })
-    return channels
+    return {"time": time_s, "channels": channels}
 
 def parse_packet(packet: bytes):
     if packet[:8] != HEADER:
         raise ValueError("Invalid packet header")
     size = struct.unpack('<I', packet[8:12])[0]
-    msg_type = struct.unpack('<B', packet[12:13])[0]
+    group_id = struct.unpack('<B', packet[12:13])[0]
     payload = packet[13:13+size-5]  # size excludes header but includes type + CRC
     crc_recv = struct.unpack('<I', packet[13+size-5:13+size-1])[0]
-    return msg_type, payload
+    return group_id, payload
 
 def parse_bin_file(file_path):
     with open(file_path, 'rb') as f:
@@ -91,16 +91,16 @@ def parse_bin_file(file_path):
                 break
             size = struct.unpack('<I', size_bytes)[0]
             packet = header + size_bytes + f.read(size)
-            msg_type, payload = parse_packet(packet)
-            if msg_type == 1:
-                parsed = parse_packet_type_1(payload)
-            elif msg_type == 2:
-                parsed = parse_packet_type_2(payload)
-            elif msg_type == 3:
-                parsed = parse_packet_type_3(payload)
+            group_id, payload = parse_packet(packet)
+            if group_id == 1:
+                parsed = parse_group_1_packet(payload)
+            elif group_id == 2:
+                parsed = parse_group_2_packet(payload)
+            elif group_id == 3:
+                parsed = parse_group_3_packet(payload)
             else:
-                parsed = {"msg_type": msg_type, "raw_payload": payload.hex()}
-            print(f"Parsed Packet Type {msg_type}:\n", parsed)
+                parsed = {"group_id": group_id, "raw_payload": payload.hex()}
+            print(f"Parsed Group {group_id}:", parsed)
             print("-"*60)
 
 def parse_folder(folder_path):
@@ -110,7 +110,5 @@ def parse_folder(folder_path):
             parse_bin_file(os.path.join(folder_path, fname))
 
 if __name__ == '__main__':
-#    folder = "log_files"  
-#    parse_folder(folder)
     file_path = input("Enter file_path:").strip()
     parse_bin_file(file_path)


### PR DESCRIPTION
• Message types are renamed as message groups to avoid confusion with Send Packet message types.
• No current pointer. We have a last_sent pointer under each group and a global pointer recording the last_sent packet group. This reduces pointers from 7 to 4 to be tracked.
• Code for bus stand-in and parser is modified to accomodate the redesign.
• Size of variables is shrinked with reduced resolution in order to include more entries per packet.
• Packet parser also reads a json file containing the same buffer entries, similar to the config.json on fsw, in order to determine number of entries in each packet and distinguish between them when reading and formatting.